### PR TITLE
Remove whitespace-nowrap from Toc component

### DIFF
--- a/components/docs/Toc.jsx
+++ b/components/docs/Toc.jsx
@@ -27,7 +27,7 @@ export default function Toc({ contents, maxHeadingLevel, indentation=2 }) {
           <ul>
             {items.map((item, idx) => {
                 return (
-                    <li className={`pl-${(item.depth - minLevel) * indentation} whitespace-nowrap mb-2`} key={idx}>
+                    <li className={`pl-${(item.depth - minLevel) * indentation} mb-2`} key={idx}>
                       <a
                         className="text-sm text-blue-900 cursor-pointer no-underline"
                         href={`#${item.slug}`}


### PR DESCRIPTION
Before:
<img width="1485" alt="Screenshot 2025-06-19 at 3 47 25 pm" src="https://github.com/user-attachments/assets/3cb28827-5b59-43d9-a34a-abd89c078d8e" />

After:
<img width="1501" alt="Screenshot 2025-06-19 at 4 30 15 pm" src="https://github.com/user-attachments/assets/5efbc7f1-4eaf-4775-95ef-af1b6a63df79" />

